### PR TITLE
fix(koa): use a named function for the remixRequestHandler and add koa's next callback

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -23,7 +23,7 @@ import type * as koa from 'koa'
  */
 export type GetLoadContextFunction = (ctx: koa.Context) => AppLoadContext
 
-export type RequestHandler = (ctx: koa.Context) => Promise<void>
+export type RequestHandler = koa.Middleware
 
 export type RequestHandlerBuilderArgs = {
 	build: ServerBuild
@@ -43,7 +43,7 @@ export function createRequestHandler({
 }: RequestHandlerBuilderArgs): RequestHandler {
 	const handleRequest = createRemixRequestHandler(build, mode)
 
-	return async (ctx) => {
+	return async function remixMiddleware(ctx, next) {
 		const request = createRemixRequest(ctx)
 		const loadContext = getLoadContext?.(ctx)
 
@@ -53,6 +53,8 @@ export function createRequestHandler({
 		)) as NodeResponse
 
 		await sendRemixResponse(ctx, response)
+
+		return next()
 	}
 }
 


### PR DESCRIPTION
![hello-obi](https://github.com/michaelhelvey/remix-koa-adapter/assets/1857967/19d8883e-398c-4f0c-ba89-13e4e8011a3f)

Love the repo !

Just wanted to fix the middleware's behavior with a `next` callback, that way we can add middlewares **after** the remix middleware.

Additionally I named the middleware function, for example if you have some profiling or opentracing setup in your application, the named middleware add some readability.

Thanks again for your work and feel free to review as harshly as you want :)